### PR TITLE
Addition of parallel compute example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ image = { version = "0.23.14", default-features = false, features = [
     "jpeg",
     "png",
 ] }
+lazy_static = "1.4.0"
 
 [features]
 integrate-image = ["image"]

--- a/examples/parallel-compute/main.rs
+++ b/examples/parallel-compute/main.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+lazy_static::lazy_static! {
+    static ref FW: gpgpu::Framework = gpgpu::Framework::default();
+}
+
+fn main() {
+    let shader = Arc::new(
+        gpgpu::utils::shader::from_wgsl_file(&FW, "examples/parallel-compute/shader.wgsl").unwrap(),
+    );
+
+    let threading = 4;
+    let size = 32000; // Must be multiple of 32
+
+    let cpu_data = (0..size).into_iter().collect::<Vec<u32>>();
+    let shader_input_buffer = Arc::new(gpgpu::GpuBuffer::from_slice(&FW, &cpu_data));
+
+    let mut handles = Vec::with_capacity(threading);
+    for _ in 0..threading {
+        let local_shader = shader.clone();
+        let local_shader_input_buffer = shader_input_buffer.clone();
+
+        let handle = std::thread::spawn(move || {
+            let local_cpu_data = (0..size).into_iter().collect::<Vec<u32>>();
+            let local_input_buffer = gpgpu::GpuBuffer::from_slice(&FW, &local_cpu_data);
+            let local_output_buffer = gpgpu::GpuBuffer::<u32>::new(&FW, size as usize);
+
+            let binds = gpgpu::DescriptorSet::default()
+                .bind_buffer(&local_shader_input_buffer, gpgpu::GpuBufferUsage::ReadOnly)
+                .bind_buffer(&local_input_buffer, gpgpu::GpuBufferUsage::ReadOnly)
+                .bind_buffer(&local_output_buffer, gpgpu::GpuBufferUsage::ReadWrite);
+
+            let kernel = &FW
+                .create_kernel_builder(&local_shader, "main")
+                .add_descriptor_set(binds)
+                .build();
+
+            kernel.enqueue(size / 32, 1, 1);
+            local_output_buffer.read().unwrap()
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        let output = handle.join().unwrap();
+
+        for (idx, a) in cpu_data.iter().enumerate() {
+            let cpu_mult = a.pow(2);
+            let gpu_mult = output[idx];
+
+            assert_eq!(cpu_mult, gpu_mult);
+        }
+    }
+}

--- a/examples/parallel-compute/shader.wgsl
+++ b/examples/parallel-compute/shader.wgsl
@@ -1,0 +1,15 @@
+[[block]]
+struct Vector {
+    data: [[stride(4)]] array<u32>;
+};
+
+[[group(0), binding(0)]] var<storage, read> a: Vector;           
+[[group(0), binding(1)]] var<storage, read> b: Vector;           
+[[group(0), binding(2)]] var<storage, read_write> c: Vector;     
+
+[[stage(compute), workgroup_size(32)]]
+fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+    let idx = global_id.x;
+
+    c.data[idx] = a.data[idx] * b.data[idx];
+}


### PR DESCRIPTION
- Check if the size must always be a multiple of the shader's workgroup size for each dimension or if it can be executed regardless.
- Consedering opening a issue in wgpu