### PR TITLE
Add `Shader::from_wgsl_string`

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -219,6 +219,20 @@ impl Shader {
             },
         )))
     }
+
+    /// Initialises a [`Shader`] from a `WGSL` string.
+    pub fn from_wgsl_string(
+        fw: &Framework,
+        source: String,
+        name: Option<&str>,
+    ) -> std::io::Result<Self> {
+        Ok(Self(fw.device.create_shader_module(
+            wgpu::ShaderModuleDescriptor {
+                label: name,
+                source: wgpu::ShaderSource::Wgsl(Cow::Owned(source)),
+            },
+        )))
+    }
 }
 
 impl<'sha, 'res> Program<'sha, 'res> {


### PR DESCRIPTION
### Summary

- Add `Shader::from_wgsl_string`, which is similar to `Shader::from_spirv_bytes`.
- For my own purpose, I needed the functionality. Do you mind adding it to this repo?