### PR TITLE
Change to different method of reading back buffers and images

### DIFF
--- a/src/primitives/buffers.rs
+++ b/src/primitives/buffers.rs
@@ -12,7 +12,7 @@ use super::BufOps;
 const GPU_BUFFER_USAGES: wgpu::BufferUsages = wgpu::BufferUsages::from_bits_truncate(
     wgpu::BufferUsages::STORAGE.bits()
         | wgpu::BufferUsages::COPY_SRC.bits()
-        | wgpu::BufferUsages::COPY_DST.bits()
+        | wgpu::BufferUsages::COPY_DST.bits(),
 );
 const GPU_UNIFORM_USAGES: wgpu::BufferUsages = wgpu::BufferUsages::from_bits_truncate(
     wgpu::BufferUsages::UNIFORM.bits() | wgpu::BufferUsages::COPY_DST.bits(),
@@ -106,10 +106,10 @@ where
             &self.fw.queue,
             &self.buf.slice(..download_size as u64),
             move |result| {
-                tx.send(result).unwrap_or_else(|_| panic!("Failed to download buffer."));
-            }
+                tx.send(result)
+                    .unwrap_or_else(|_| panic!("Failed to download buffer."));
+            },
         );
-        self.fw.device.poll(wgpu::Maintain::Wait);
         let download = rx.await.unwrap().unwrap();
 
         buf.copy_from_slice(bytemuck::cast_slice(&download));

--- a/src/primitives/buffers.rs
+++ b/src/primitives/buffers.rs
@@ -13,8 +13,6 @@ const GPU_BUFFER_USAGES: wgpu::BufferUsages = wgpu::BufferUsages::from_bits_trun
     wgpu::BufferUsages::STORAGE.bits()
         | wgpu::BufferUsages::COPY_SRC.bits()
         | wgpu::BufferUsages::COPY_DST.bits()
-        | wgpu::BufferUsages::MAP_READ.bits()
-        | wgpu::BufferUsages::MAP_WRITE.bits(),
 );
 const GPU_UNIFORM_USAGES: wgpu::BufferUsages = wgpu::BufferUsages::from_bits_truncate(
     wgpu::BufferUsages::UNIFORM.bits() | wgpu::BufferUsages::COPY_DST.bits(),
@@ -102,16 +100,19 @@ where
             output_size
         };
 
-        let download = self.buf.slice(..download_size as u64);
-
         let (tx, rx) = futures::channel::oneshot::channel();
-        download.map_async(MapMode::Read, |result| {
-            tx.send(result).expect("GpuBuffer reading error!");
-        });
-        rx.await
-            .expect("GpuBuffer futures::channel::oneshot error")?;
+        wgpu::util::DownloadBuffer::read_buffer(
+            &self.fw.device,
+            &self.fw.queue,
+            &self.buf.slice(..download_size as u64),
+            move |result| {
+                tx.send(result).unwrap_or_else(|_| panic!("Failed to download buffer."));
+            }
+        );
+        self.fw.device.poll(wgpu::Maintain::Wait);
+        let download = rx.await.unwrap().unwrap();
 
-        buf.copy_from_slice(bytemuck::cast_slice(&download.get_mapped_range()));
+        buf.copy_from_slice(bytemuck::cast_slice(&download));
 
         Ok(download_size)
     }

--- a/src/primitives/images.rs
+++ b/src/primitives/images.rs
@@ -179,8 +179,7 @@ where
         let staging = self.fw.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("GpuImage::read"),
             size: staging_size as u64,
-            usage: wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::COPY_DST,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -217,10 +216,10 @@ where
             &self.fw.queue,
             &staging.slice(..),
             move |result| {
-                tx.send(result).unwrap_or_else(|_| panic!("Failed to download buffer."));
-            }
+                tx.send(result)
+                    .unwrap_or_else(|_| panic!("Failed to download buffer."));
+            },
         );
-        self.fw.device.poll(wgpu::Maintain::Wait);
         let download = rx.await.unwrap().unwrap();
 
         let bytes_read: usize = download


### PR DESCRIPTION
Hey there. Before any of the details, I want to add a disclaimer that I am not an expert on `wgpu` at all.

I was investigating a bug that I thought might stem from this crate, so I tried using the version on `dev` branch instead. However, after changing to the this version, the performance of my usecase regressed to a pretty extreme degree (roughly 100x slowdown). On top of that, I kept getting panics with messages like "Buffer is still mapped" on compute shader dispatches, even though I _only_ use the blocking versions of the API. I bisected and found that your changes to buffer reads in this commit https://github.com/UpsettingBoy/gpgpu-rs/commit/dd0109538edd57c923db0f69182d605472cca346 were the culprit.

I then fiddled around a bit with an alternative way to implement these functions. The changes in this PR are what I came up with. They seem to be functionally equivalent, and solved the random panics as well as the massive performance regression. As for why exactly that is, I'm not sure. I think it might have something to do with the `MAP_READ` and `MAP_WRITE` flags you added.

I don't think the `poll` call is strictly necessary, didn't make a difference in my testing, but it is based on the code here https://sotrh.github.io/learn-wgpu/news/0.13/.

I leave it up to you whether you want to consider merging these changes or not. I like your crate a lot, but future versions of it will be completely unusable for me with the changes currently on `dev`. I can give you more info on my usecase if you want, but it's quite simple - a single compute shader being enqueued in a loop, blocking readback every N dispatches. Relevant code is here https://github.com/pema99/rust-pt-electric-boogaloo/blob/master/src/trace.rs#L86-L91