### PR TITLE
Add 32 bit float image support, update image dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ image = { version = "0.24.6", default-features = false, features = [
     "png",
 ] }
 lazy_static = "1.4.0"
-nokhwa = { version = "0.9.4", features = ["input-v4l", "input-msmf"] }
+nokhwa = { version = "0.10.0", features = ["input-v4l", "input-msmf"] }
 minifb = "0.23.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://www.github.com/UpsettingBoy/gpgpu-rs"
 bytemuck = "1.7"
 cfg-if = "1.0"
 futures = { version = "0.3", default-features = false, features = ["executor"] }
-image = { version = "0.23", default-features = false, optional = true }
+image = { version = "0.24.6", default-features = false, optional = true }
 wgpu = { version = "0.14", features = ["spirv"] }
 ndarray = { version = "0.15", default-features = false, features = [
     "std",
@@ -25,7 +25,7 @@ thiserror = "1.0"
 log = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-image = { version = "0.23.14", default-features = false, features = [
+image = { version = "0.24.6", default-features = false, features = [
     "jpeg",
     "png",
 ] }

--- a/examples/webcam/main.rs
+++ b/examples/webcam/main.rs
@@ -8,9 +8,7 @@ use gpgpu::{
 use minifb::{Key, Window, WindowOptions};
 use nokhwa::{
     pixel_format::RgbAFormat,
-    utils::{
-        CameraFormat, CameraIndex, FrameFormat, RequestedFormat, RequestedFormatType, Resolution,
-    },
+    utils::{CameraIndex, RequestedFormat, RequestedFormatType},
     Camera,
 };
 

--- a/examples/webcam/main.rs
+++ b/examples/webcam/main.rs
@@ -7,9 +7,11 @@ use gpgpu::{
 
 use minifb::{Key, Window, WindowOptions};
 use nokhwa::{
+    pixel_format::RgbAFormat,
+    utils::{
+        CameraFormat, CameraIndex, FrameFormat, RequestedFormat, RequestedFormatType, Resolution,
+    },
     Camera,
-    utils::{CameraFormat, Resolution, RequestedFormat, RequestedFormatType, CameraIndex, FrameFormat},
-    pixel_format::RgbAFormat
 };
 
 const WIDTH: usize = 1280;
@@ -21,7 +23,8 @@ fn main() {
     // Camera initilization. Config may not work if not same cam as the Thinkpad T480 one.
     // Change parameters accordingly
     let mut camera = {
-        let requested = RequestedFormat::new::<RgbAFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
+        let requested =
+            RequestedFormat::new::<RgbAFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
         Camera::new(CameraIndex::Index(0), requested).unwrap()
     };
 

--- a/examples/webcam/main.rs
+++ b/examples/webcam/main.rs
@@ -6,7 +6,11 @@ use gpgpu::{
 };
 
 use minifb::{Key, Window, WindowOptions};
-use nokhwa::{Camera, CameraFormat, Resolution};
+use nokhwa::{
+    Camera,
+    utils::{CameraFormat, Resolution, RequestedFormat, RequestedFormatType, CameraIndex, FrameFormat},
+    pixel_format::RgbAFormat
+};
 
 const WIDTH: usize = 1280;
 const HEIGHT: usize = 720;
@@ -17,16 +21,8 @@ fn main() {
     // Camera initilization. Config may not work if not same cam as the Thinkpad T480 one.
     // Change parameters accordingly
     let mut camera = {
-        let camera_format = CameraFormat::new(
-            Resolution {
-                width_x: WIDTH as u32,
-                height_y: HEIGHT as u32,
-            },
-            nokhwa::FrameFormat::MJPEG,
-            30,
-        );
-
-        Camera::new(0, Some(camera_format)).unwrap()
+        let requested = RequestedFormat::new::<RgbAFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
+        Camera::new(CameraIndex::Index(0), requested).unwrap()
     };
 
     // Window initialization
@@ -70,7 +66,7 @@ fn main() {
 
         // Adapted for new (using image 0.24) nokhwa version
         let cam_raw = camera.frame().unwrap();
-        let cam_buf = image::DynamicImage::ImageRgb8(cam_raw).into_rgba8(); // Obtain cam current frame
+        let cam_buf = cam_raw.decode_image::<RgbAFormat>().unwrap(); // Obtain cam current frame
 
         gpu_input.write_image_buffer(&cam_buf).unwrap(); // Upload cam frame into the cam frame texture
         buf_time.write(&[time.elapsed().as_secs_f32()]).unwrap(); // Upload elapsed time into elapsed time buffer

--- a/src/features/integrate_image.rs
+++ b/src/features/integrate_image.rs
@@ -44,13 +44,15 @@ macro_rules! gpgpu_to_image_impl {
 
 gpgpu_to_image_impl! {
     ::image::Rgba<u8>, pixels::Rgba8Uint, pixels::Rgba8UintNorm;
-    ::image::Rgba<i8>, pixels::Rgba8Sint, pixels::Rgba8SintNorm
+    ::image::Rgba<i8>, pixels::Rgba8Sint, pixels::Rgba8SintNorm;
+    ::image::Rgba<f32>, pixels::Rgba32Float
     // ::image::Luma<u8>, pixels::Luma8, pixels::Luma8Norm
 }
 
 image_to_gpgpu_impl! {
     ::image::Rgba<u8>, pixels::Rgba8Uint, pixels::Rgba8UintNorm;
-    ::image::Rgba<i8>, pixels::Rgba8Sint, pixels::Rgba8SintNorm
+    ::image::Rgba<i8>, pixels::Rgba8Sint, pixels::Rgba8SintNorm;
+    ::image::Rgba<f32>, pixels::Rgba32Float, pixels::Rgba32Float
     // ::image::Luma<u8>, pixels::Luma8, pixels::Luma8Norm
 }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -147,7 +147,8 @@ pub mod pixels {
         Rgba8Uint, 4, wgpu::TextureFormat::Rgba8Uint, wgpu::TextureSampleType::Uint, #[doc = "Red, green, blue, and alpha channels. 8 bit integer per channel. Unsigned in shader."];
         Rgba8UintNorm, 4, wgpu::TextureFormat::Rgba8Unorm, wgpu::TextureSampleType::Float { filterable: true }, #[doc = "Red, green, blue, and alpha channels. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader."];
         Rgba8Sint, 4, wgpu::TextureFormat::Rgba8Sint, wgpu::TextureSampleType::Sint, #[doc = "Red, green, blue, and alpha channels. 8 bit integer per channel. Signed in shader."];
-        Rgba8SintNorm, 4, wgpu::TextureFormat::Rgba8Snorm, wgpu::TextureSampleType::Float { filterable: true }, #[doc = "Red, green, blue, and alpha channels. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader."]
+        Rgba8SintNorm, 4, wgpu::TextureFormat::Rgba8Snorm, wgpu::TextureSampleType::Float { filterable: true }, #[doc = "Red, green, blue, and alpha channels. 8 bit integer per channel. [-127, 127] converted to/from float [-1, 1] in shader."];
+        Rgba32Float, 16, wgpu::TextureFormat::Rgba32Float, wgpu::TextureSampleType::Float { filterable: true }, #[doc = "Red, green, blue, and alpha channels. 32 bit float per channel. Float in shader."]
         // Luma8, 1, wgpu::TextureFormat::R8Uint, wgpu::TextureSampleType::Uint, #[doc = "Grayscale 8 bit integer channel. Unsigned in shader."];
         // Luma8Norm, 1, wgpu::TextureFormat::R8Unorm, wgpu::TextureSampleType::Float { filterable: false }, #[doc = "Grayscale 8 bit integer channel. Unsigned in shader. [0, 255] converted to/from float [0, 1] in shader."]
     }


### PR DESCRIPTION
This PR adds support for binding single precision floating point images to compute shaders. This was useful in my case for binding skybox textures with HDR values. Another potential use case is storing weights for ML purposes.

I also took the liberty of bumping the `image` dependency. Newer versions of the image crate support more HDR image formats, such as EXR.

I also had to bump the `nokhwa` dependency to avoid duplicate versions `image`, and fixed the Webcam example accordingly. I've tested locally that the webcam example still works the same after my changes.