### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 keywords = ["gpgpu", "compute", "opencl", "cuda"]
 license = "EUPL-1.2"
 name = "gpgpu"
-repository = "https://www.github.com/UpsettingBoy/gpgpu-rs"
+repository = "https://github.com/UpsettingBoy/gpgpu-rs"
 resolver = "2"
 version = "0.2.0"
-homepage = "https://www.github.com/UpsettingBoy/gpgpu-rs"
+homepage = "https://github.com/UpsettingBoy/gpgpu-rs"
 
 
 [dependencies]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96